### PR TITLE
Create collect-feedback-about-devpro-product

### DIFF
--- a/.github/ISSUE_TEMPLATE/collect-feedback-about-devpro-product
+++ b/.github/ISSUE_TEMPLATE/collect-feedback-about-devpro-product
@@ -1,0 +1,20 @@
+---
+name: Collect feedback for DevPro
+about: Name the existing feature/product of DevPro
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Provide the link to the feature/product description**
+Products can be find here https://animated-adventure-wl8rqgk.pages.github.io/
+
+**Provide why do you need a feedback**
+A clear and concise description of what you want to happen.
+
+**Do you only collect feedback or might discussions also happen here?**
+Would there be another place where you expect the deeper discussion to happen and where clarification questions are asked?
+
+**Additional context**
+Add any other context or screenshots here.


### PR DESCRIPTION
I want to use the issues in "platform" repo more for DevPro and use it for both sides: request features from DevPro and collect feedback for DevPro.  That's why I would like to have another template for us only